### PR TITLE
File saving

### DIFF
--- a/Source/ObsBuddy.py
+++ b/Source/ObsBuddy.py
@@ -25,7 +25,7 @@ startTime = 0
 splitStartTime  = 0
 
 #Minimum split time (seconds)?
-MIN_SPLIT_TIME = 3
+MIN_SPLIT_TIME = 2
 
 #Global for how many splits
 splitCounter = 0
@@ -65,7 +65,6 @@ def script_update(settings):
 
     if (DEBUG_MODE): 
         print("Calling Update")
-        print(math.floor(time.time()))
 
     #Update value of enabled
     isEnabled = obs.obs_data_get_bool(settings, "enabled")
@@ -86,29 +85,23 @@ def onRecordingStart():
     global isRecording
     global startTime
     global splitCounter
-
-    if(DEBUG_MODE):
-        print("onRecordingStart Ran")
-        print(isRecording)
     
     if(isEnabled and obs.obs_frontend_recording_active() and not isRecording):
+        if DEBUG_MODE:
+            print("Timer Start")
         isRecording = True
         splitCounter = 0
         startTime = math.floor(time.time())
-        print("Timer Start")
-        print(startTime)
         
 
 def onRecordingEnd():
     global isRecording
     global startTime
 
-    if(DEBUG_MODE):
-        print("onRecordingEnd Ran")
-
     if(isEnabled and not obs.obs_frontend_recording_active() and isRecording):
+        if DEBUG_MODE:
+            print("Timer End")
         isRecording = False
-        print("Timer End")
 
 def handleSplits(isPressed):
     global startTime
@@ -119,14 +112,15 @@ def handleSplits(isPressed):
 
     if(isRecording and isEnabled and math.floor(time.time()) - offsetTimer > OFFSET):
         if(splitStartTime == 0):
+            if DEBUG_MODE:
+                print("Split started")
             splitStartTime = math.floor(time.time())
-            print("Split started", splitStartTime)
             offsetTimer = 0
         else:
             endTime =  math.floor(time.time()) - splitStartTime
-            print(endTime)
             if(endTime > MIN_SPLIT_TIME):
-                print("Split ended")
+                if DEBUG_MODE:
+                    print("Split ended")
                 splitCounter += 1
                 saveTimes(splitStartTime - startTime, endTime)
                 splitStartTime = 0
@@ -140,12 +134,10 @@ def saveTimes(startTime, endTime):
 
     currentDirectory = os.getcwd()
     os.chdir(os.path.dirname(__file__))
-    print(os.getcwd())
     savePath = os.path.relpath('..\\Splits\\splits.txt', os.path.dirname(__file__))
     file = io.open(savePath, "a+")
     file.write("Split" + str(splitCounter) + ": Start time-" + str(startTime) + " End time-" + str(endTime) + "\n")
     file.close()
     os.chdir(currentDirectory)
-    print(os.getcwd())
 
 

--- a/Source/ObsBuddy.py
+++ b/Source/ObsBuddy.py
@@ -1,20 +1,49 @@
 #Just prints something when recording starts (must be enabled obviously)
 
+#LOTS OF GLOBALS. I do not think I can pass parameters to these functions so the globals
+#are neseccary atm. I will test this later.
+
 #Obs module, Python will say it cant find it but if its ran in OBS it will work
 import obspython as obs
+import time
+import math
+import io
+import os
 
 #Global for debug messages
-DEBUG_MODE = True
+DEBUG_MODE = False
 
 #Global for whether the script is enabled because the obs call for that is long
-ENABLED = False
+isEnabled = False
+
+#Global to help tell when OBS has stopped recording
+isRecording = False
+
+#Globals for keeping track of times
+startTime = 0
+
+splitStartTime  = 0
+
+#Minimum split time (seconds)?
+MIN_SPLIT_TIME = 3
+
+#Global for how many splits
+splitCounter = 0
+
+#LFSLKFNDSLKFNSLKFNSLKFN OBS SUCKS AND REGISTERS KEY UP AND KEY DOWN AS SEPERATE HOTKEY
+#EVENTS. SO I NEED AN OFFEST TIMER TO PREVENT A SPLIT STARTING RIGHT AFTER A SPLIT ENDS
+#FROM THE KEY UP. THIS MEANS IT IS IMPOSSIBLE TO START A SPLIT 3 SECONDS AFTER ENDING ONE.
+OFFSET = 3
+offsetTimer = 0
 
 #OBS function, loads script. Sets enabled to false on load.
 def script_load(settings):
     if (DEBUG_MODE): 
         print("Calling Load")
-        
+
     obs.obs_data_set_bool(settings, "enabled", False)
+    obs.obs_data_set_bool(settings, "debugMode", False)
+    obs.obs_hotkey_register_frontend("bsdjhgbsdkjhgbjhgb", "fvhvnvgnvn", handleSplits)
 
 #Creats the enabled property when the script is instanited
 def script_properties():
@@ -23,28 +52,100 @@ def script_properties():
         
     props = obs.obs_properties_create()
     obs.obs_properties_add_bool(props, "enabled", "Enabled")
+    obs.obs_properties_add_path(props, "filePath", "File Path", obs.OBS_PATH_DIRECTORY, None, None)
+    obs.obs_properties_add_bool(props, "debugMode", "Debug Mode")
     
     return props
 
 #This script is ran when a property is changed inside the OBS UI.
 #Updates variables based on the property changes.
 def script_update(settings):
+    global isEnabled
+    global DEBUG_MODE
+
     if (DEBUG_MODE): 
         print("Calling Update")
+        print(math.floor(time.time()))
 
     #Update value of enabled
-    ENABLED = obs.obs_data_get_bool(settings, "enabled")
+    isEnabled = obs.obs_data_get_bool(settings, "enabled")
+    DEBUG_MODE = obs.obs_data_get_bool(settings, "debugMode")
+
+    print(isEnabled)
 
     #Add or remove functions based on whether the script is enabled
-    if(ENABLED):
-        obs.timer_add(OnRecordingStart, 1000)
+    if(isEnabled):
+        obs.timer_add(onRecordingStart, 1000)
+        obs.timer_add(onRecordingEnd, 100)
     else:
-        obs.timer_remove(OnRecordingStart)
+        obs.timer_remove(onRecordingStart)
+        obs.timer_remove(onRecordingEnd)
 
 #If OBS is recording and this script is Enabled. Print Something.
-def OnRecordingStart():
+def onRecordingStart():
+    global isRecording
+    global startTime
+    global splitCounter
+
     if(DEBUG_MODE):
-        print("It ran")
-    if(ENABLED and obs. obs_frontend_recording_active()):
-        print("Subsribe to ZardyZ")
+        print("onRecordingStart Ran")
+        print(isRecording)
+    
+    if(isEnabled and obs.obs_frontend_recording_active() and not isRecording):
+        isRecording = True
+        splitCounter = 0
+        startTime = math.floor(time.time())
+        print("Timer Start")
+        print(startTime)
         
+
+def onRecordingEnd():
+    global isRecording
+    global startTime
+
+    if(DEBUG_MODE):
+        print("onRecordingEnd Ran")
+
+    if(isEnabled and not obs.obs_frontend_recording_active() and isRecording):
+        isRecording = False
+        print("Timer End")
+
+def handleSplits(isPressed):
+    global startTime
+    global splitStartTime
+    global isRecording
+    global splitCounter
+    global offsetTimer
+
+    if(isRecording and isEnabled and math.floor(time.time()) - offsetTimer > OFFSET):
+        if(splitStartTime == 0):
+            splitStartTime = math.floor(time.time())
+            print("Split started", splitStartTime)
+            offsetTimer = 0
+        else:
+            endTime =  math.floor(time.time()) - splitStartTime
+            print(endTime)
+            if(endTime > MIN_SPLIT_TIME):
+                print("Split ended")
+                splitCounter += 1
+                saveTimes(splitStartTime - startTime, endTime)
+                splitStartTime = 0
+                offsetTimer = math.floor(time.time())
+            
+
+
+#CONFUSING VARIABLE NAMES. FIX??
+def saveTimes(startTime, endTime):
+    global splitCounter
+
+    currentDirectory = os.getcwd()
+    os.chdir(os.path.dirname(__file__))
+    print(os.getcwd())
+    savePath = os.path.relpath('..\\Splits\\splits.txt', os.path.dirname(__file__))
+    file = io.open(savePath, "a+")
+    file.write("Split" + str(splitCounter) + ": Start time-" + str(startTime) + " End time-" + str(endTime) + "\n")
+    file.close()
+    os.chdir(currentDirectory)
+    print(os.getcwd())
+
+

--- a/Source/ObsBuddy.py
+++ b/Source/ObsBuddy.py
@@ -3,8 +3,6 @@
 #Obs module, Python will say it cant find it but if its ran in OBS it will work
 import obspython as obs
 
-#Test for commits
-
 #Global for debug messages
 DEBUG_MODE = True
 

--- a/Source/ObsBuddy.py
+++ b/Source/ObsBuddy.py
@@ -43,7 +43,7 @@ def script_load(settings):
 
     obs.obs_data_set_bool(settings, "enabled", False)
     obs.obs_data_set_bool(settings, "debugMode", False)
-    obs.obs_hotkey_register_frontend("bsdjhgbsdkjhgbjhgb", "fvhvnvgnvn", handleSplits)
+    obs.obs_hotkey_register_frontend("splitHotkey", "Split Hotkey", handleSplits)
 
 #Creats the enabled property when the script is instanited
 def script_properties():
@@ -65,12 +65,11 @@ def script_update(settings):
 
     if (DEBUG_MODE): 
         print("Calling Update")
+        print("isEnabled:", isEnabled)
 
     #Update value of enabled
     isEnabled = obs.obs_data_get_bool(settings, "enabled")
     DEBUG_MODE = obs.obs_data_get_bool(settings, "debugMode")
-
-    print(isEnabled)
 
     #Add or remove functions based on whether the script is enabled
     if(isEnabled):

--- a/Source/ObsBuddy.py
+++ b/Source/ObsBuddy.py
@@ -3,6 +3,8 @@
 #Obs module, Python will say it cant find it but if its ran in OBS it will work
 import obspython as obs
 
+#Test for commits
+
 #Global for debug messages
 DEBUG_MODE = True
 

--- a/Splits/splits.txt
+++ b/Splits/splits.txt
@@ -1,0 +1,4 @@
+Split1: Start time-5 End time-5
+Split2: Start time--1624050499 End time-1624050510
+Split1: Start time-5 End time-5
+Split2: Start time-15 End time-6


### PR DESCRIPTION
Changes
Altered ObsBuddy.py to track recording start time. Added a hotkey in OBS-that must be bound in OBs- to start and stop splits during recording. These splits are saved under the splits directory in a .txt data file. 
Verification
Add script to OBS through tool->scripts. Enable the script, and bind the hotkey through OBS. It is labeled "Split Hotkey". Start a recording, and press the hotkey a few seconds later. Wait for a few seconds, and press the hotkey again. Check under the splits directory and you should see new time stamps. If Debug Mode is enable then you should also see print statements verifying these events are happening.
